### PR TITLE
add a simple responsive navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-bootstrap": "^2.4.0",
         "react-dom": "^18.1.0",
         "react-redux": "^8.0.2",
+        "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
         "web-vitals": "^2.1.4"
@@ -8552,6 +8553,14 @@
         "he": "bin/he"
       }
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -14192,6 +14201,30 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "dependencies": {
+        "history": "^5.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "dependencies": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -23035,6 +23068,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -26971,6 +27012,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.3.0"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-bootstrap": "^2.4.0",
     "react-dom": "^18.1.0",
     "react-redux": "^8.0.2",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
     "web-vitals": "^2.1.4"

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
       integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
       crossorigin="anonymous"
     />
-    <title>React App</title>
+    <title>Something Borrowed</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,30 @@
-import { useEffect } from 'react'
+import { Routes, Route } from 'react-router-dom'
+
+import MyItemsPage from './components/MyItemsPage'
+import MarketplacePage from './components/MarketplacePage'
+import LoginPage from './components/LoginPage'
+import ProfilePage from './components/ProfilePage'
+
 import './styles.css'
 
 function App () {
-  useEffect(() => {
-    document.title = 'Something Borrowed'
-  })
-
   return (
-    <div className="App">
-    </div>
+    <>
+      <Routes>
+        <Route path="/" element={<LoginPage />} />
+        <Route path="/my-items" element={<MyItemsPage />} />
+        <Route path="/marketplace" element={<MarketplacePage />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route
+          path="*"
+          element={
+            <main style={{ padding: '1rem' }}>
+              <p>There's nothing here!</p>
+            </main>
+          }
+        />
+      </Routes>
+    </>
   )
 }
 

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -2,9 +2,11 @@ import { useState } from 'react'
 import { Form, Button, Stack } from 'react-bootstrap'
 import { useDispatch } from 'react-redux'
 import { loginUser } from '../redux/users/user'
+import { useNavigate } from 'react-router-dom'
 
 export default function LoginForm () {
   const dispatch = useDispatch()
+  const navigate = useNavigate()
 
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -19,7 +21,7 @@ export default function LoginForm () {
     dispatch(loginUser({ username, isLoggedIn: true }))
     // When we have react-router set up, can uncomment the line below (and maybe fix the path)
     // so the login button redirects to the home page
-    // useNavigate('/')
+    navigate('/marketplace')
   }
 
   return (

--- a/src/components/MarketplacePage.jsx
+++ b/src/components/MarketplacePage.jsx
@@ -1,0 +1,12 @@
+import NavBar from './NavBar'
+
+function MarketplacePage () {
+  return (
+    <>
+      <NavBar />
+      <h1>Marketplace</h1>
+    </>
+  )
+}
+
+export default MarketplacePage

--- a/src/components/MyItemsPage.jsx
+++ b/src/components/MyItemsPage.jsx
@@ -6,16 +6,16 @@ import NavBar from './NavBar'
 
 import '../styles.css'
 
-function AddItemPage () {
+function MyItemsPage () {
   return (
     <>
       <NavBar />
-      <h1 className="page-title">Add Item to Profile</h1>
       <div className="grid-container">
         <div className="grid-child page-container">
           <AddItemForm />
         </div>
         <div className="grid-child page-container" id="container-border">
+          <h2>My Items</h2>
           <ItemContainer />
         </div>
       </div>
@@ -23,4 +23,4 @@ function AddItemPage () {
   )
 }
 
-export default AddItemPage
+export default MyItemsPage

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,31 +1,22 @@
-import React from 'react'
-import Container from 'react-bootstrap/Container'
-import Navbar from 'react-bootstrap/Navbar'
-import Nav from 'react-bootstrap/Nav'
+import { Navbar, Container, Nav } from 'react-bootstrap'
+import { NavLink } from 'react-router-dom'
 
 import '../styles.css'
 
-export default function NavBar (prop) {
+export default function NavBar () {
   return (
-    <>
-      <Navbar className="navbar-parent">
-        <Container fluid>
-          <Navbar.Brand href="#home">
-            {/* <img
-              src="image"
-              width="30"
-              height="30"
-              className="App-logo"
-              alt="Something Borrowed"
-            /> */}
-            Something Borrowed
-          </Navbar.Brand>
-          <Nav>
-            <Nav.Link to="home">Home</Nav.Link>
-            <Nav.Link to="addItem">Add Item To Profile</Nav.Link>
+    <Navbar bg="light" expand="lg">
+      <Container fluid>
+        <Navbar.Brand as={NavLink} to="/marketplace">Something Borrowed</Navbar.Brand>
+        <Navbar.Toggle />
+        <Navbar.Collapse id="basic-navbar-nav">
+          <Nav className="ms-auto">
+            <Nav.Link as={NavLink} to="/marketplace">Marketplace</Nav.Link>
+            <Nav.Link as={NavLink} to="/my-items">My Items</Nav.Link>
+            <Nav.Link as={NavLink} to="/profile">Profile</Nav.Link>
           </Nav>
-        </Container>
-      </Navbar>
-    </>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
   )
 }

--- a/src/components/ProfilePage.jsx
+++ b/src/components/ProfilePage.jsx
@@ -1,0 +1,12 @@
+import NavBar from './NavBar'
+
+function ProfilePage () {
+  return (
+    <>
+      <NavBar />
+      <h1>Profile</h1>
+    </>
+  )
+}
+
+export default ProfilePage

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,19 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import './index.css'
-
-import LoginPage from './components/LoginPage'
+import { BrowserRouter } from 'react-router-dom'
 import { store } from './redux/store'
 import { Provider } from 'react-redux'
+
+import App from './App'
+import './index.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <LoginPage />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </Provider>
   </React.StrictMode>
 )


### PR DESCRIPTION
Added a simple, responsive navbar. Uses `react-router` and highlights the currently active link. Not much styling, but should be easy to add a logo, colours, etc. if someone wants. 

This commit also implements the basic flow of the app: it shows the login page, the user can login, then they're taken to the Marketplace page and can navigate around. 

This is intended as an alternative to #44 . In my opinion it's better to use the library components to get the functionality we want (responsiveness, active link highlighting) and add styling on top. 

(Let me know if this gif doesn't work)
![demo](https://user-images.githubusercontent.com/6674293/175205903-d2aefaf1-7f04-405c-af34-f390a9935ee2.gif)
 